### PR TITLE
Disable HTML formatters and fix permissions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,6 +13,8 @@ on:
 
 permissions:
   contents: read
+  statuses: write
+  pull-requests: write
 
 # A workflow run is made up of one or more jobs that can run sequentially
 # or in parallel
@@ -49,3 +51,5 @@ jobs:
           VALIDATE_PYTHON_PYLINT: false
           VALIDATE_JSCPD: false
           VALIDATE_JSON_PRETTIER: false
+          VALIDATE_HTML: false
+          VALIDATE_HTML_PRETTIER: false


### PR DESCRIPTION
- Disable VALIDATE_HTML and VALIDATE_HTML_PRETTIER formatters
- Add statuses:write and pull-requests:write permissions to fix 403 errors when calling GitHub Status API